### PR TITLE
Changed backend adress

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -12,7 +12,7 @@ class CommonSettings(BaseSettings):
 
 
 class ServerSettings(BaseSettings):
-    HOST: str = "0.0.0.0"
+    HOST: str = "127.0.0.1"
     PORT: int = 8000
 
 


### PR DESCRIPTION
Fixed #28 by changing backend address from 0.0.0.0 which doesn't work in Windows to 127.0.0.1. In reality it only works in Linux because it actually changes the address 0.0.0.0 to localhost (127.0.0.1), so having already this one makes it more robust